### PR TITLE
simulator (optimism): rm unnecessary sleep

### DIFF
--- a/simulators/optimism/devnet/main.go
+++ b/simulators/optimism/devnet/main.go
@@ -76,10 +76,6 @@ func runAllTests(t *hivesim.T) {
 
 	c := d.l2.Client
 
-	// TODO: run integration tests
-	time.Sleep(30 * time.Second)
-	// write your test code here
-
 	vault := newVault()
 	genesis := []byte(d.l2Genesis)
 


### PR DESCRIPTION
I had a sleep timer which inadvertently crept in. Removing this should speed up the test runner as well.