### PR TITLE
[wip] restore codeAt test replacing pre-deploy contract address

### DIFF
--- a/simulators/optimism/devnet/ethclient.go
+++ b/simulators/optimism/devnet/ethclient.go
@@ -83,6 +83,16 @@ func genesisBlockByNumberTest(t *TestEnv) {
 	}
 }
 
+// CodeAtTest tests the code for the pre-deployed contract.
+func CodeAtTest(t *TestEnv) {
+	code, err := t.Eth.CodeAt(t.Ctx(), t.deployedContractAddr, big0)
+	if err != nil {
+		t.Fatalf("Could not fetch code for predeployed contract: %v", err)
+	}
+	if bytes.Compare(runtimeCode, code) != 0 {
+		t.Fatalf("Unexpected code, want %x, got %x", runtimeCode, code)
+	}
+}
 
 // deployContractTest deploys `contractSrc` and tests if the code and state
 // on the contract address contain the expected values (as set in the ctor).
@@ -139,6 +149,8 @@ func deployContractTest(t *TestEnv) {
 	} else {
 		t.Errorf("Unable to retrieve storage pos 0x01 on address %x: %v", contractAddress, err)
 	}
+
+	t.deployedContractAddr = contractAddress
 
 	// test contract state, map on pos 1 with key myAccount must be 1234
 	storageKey := make([]byte, 64)

--- a/simulators/optimism/devnet/ethclient.go
+++ b/simulators/optimism/devnet/ethclient.go
@@ -83,11 +83,11 @@ func genesisBlockByNumberTest(t *TestEnv) {
 	}
 }
 
-// CodeAtTest tests the code for the pre-deployed contract.
+// CodeAtTest tests the code for the deployed contract.
 func CodeAtTest(t *TestEnv) {
-	code, err := t.Eth.CodeAt(t.Ctx(), t.Config.DeployedContractAddr, big0)
+	code, err := t.Eth.CodeAt(t.Ctx(), t.Config.DeployedContractAddr, nil)
 	if err != nil {
-		t.Fatalf("Could not fetch code for predeployed contract: %v", err)
+		t.Fatalf("Could not fetch code for deployed contract: %v", err)
 	}
 	if bytes.Compare(runtimeCode, code) != 0 {
 		t.Fatalf("Unexpected code, want %x, got %x", runtimeCode, code)

--- a/simulators/optimism/devnet/ethclient.go
+++ b/simulators/optimism/devnet/ethclient.go
@@ -85,7 +85,7 @@ func genesisBlockByNumberTest(t *TestEnv) {
 
 // CodeAtTest tests the code for the pre-deployed contract.
 func CodeAtTest(t *TestEnv) {
-	code, err := t.Eth.CodeAt(t.Ctx(), t.deployedContractAddr, big0)
+	code, err := t.Eth.CodeAt(t.Ctx(), t.Config.DeployedContractAddr, big0)
 	if err != nil {
 		t.Fatalf("Could not fetch code for predeployed contract: %v", err)
 	}
@@ -98,7 +98,7 @@ func CodeAtTest(t *TestEnv) {
 // on the contract address contain the expected values (as set in the ctor).
 func deployContractTest(t *TestEnv) {
 	var (
-		address = t.Vault.createAccount(t, big.NewInt(params.Ether))
+		address = t.Config.Vault.createAccount(t, big.NewInt(params.Ether))
 		nonce   = uint64(0)
 
 		expectedContractAddress = crypto.CreateAddress(address, nonce)
@@ -106,7 +106,7 @@ func deployContractTest(t *TestEnv) {
 	)
 
 	rawTx := types.NewContractCreation(nonce, big0, gasLimit, gasPrice, deployCode)
-	deployTx, err := t.Vault.signTransaction(address, rawTx)
+	deployTx, err := t.Config.Vault.signTransaction(address, rawTx)
 	if err != nil {
 		t.Fatalf("Unable to sign deploy tx: %v", err)
 	}
@@ -150,8 +150,6 @@ func deployContractTest(t *TestEnv) {
 		t.Errorf("Unable to retrieve storage pos 0x01 on address %x: %v", contractAddress, err)
 	}
 
-	t.deployedContractAddr = contractAddress
-
 	// test contract state, map on pos 1 with key myAccount must be 1234
 	storageKey := make([]byte, 64)
 	copy(storageKey[12:32], address.Bytes())
@@ -174,7 +172,7 @@ func deployContractTest(t *TestEnv) {
 // the contract address.
 func deployContractOutOfGasTest(t *TestEnv) {
 	var (
-		address         = t.Vault.createAccount(t, big.NewInt(params.Ether))
+		address         = t.Config.Vault.createAccount(t, big.NewInt(params.Ether))
 		nonce           = uint64(0)
 		contractAddress = crypto.CreateAddress(address, nonce)
 		gasLimit        = uint64(240000) // insufficient gas
@@ -183,7 +181,7 @@ func deployContractOutOfGasTest(t *TestEnv) {
 
 	// Deploy the contract.
 	rawTx := types.NewContractCreation(nonce, big0, gasLimit, gasPrice, deployCode)
-	deployTx, err := t.Vault.signTransaction(address, rawTx)
+	deployTx, err := t.Config.Vault.signTransaction(address, rawTx)
 	if err != nil {
 		t.Fatalf("unable to sign deploy tx: %v", err)
 	}
@@ -261,9 +259,9 @@ func newHeadSubscriptionTest(t *TestEnv) {
 // address are updated correct.
 func balanceAndNonceAtTest(t *TestEnv) {
 	var (
-		sourceAddr  = t.Vault.createAccount(t, big.NewInt(params.Ether))
+		sourceAddr  = t.Config.Vault.createAccount(t, big.NewInt(params.Ether))
 		sourceNonce = uint64(0)
-		targetAddr  = t.Vault.createAccount(t, nil)
+		targetAddr  = t.Config.Vault.createAccount(t, nil)
 	)
 
 	// Get current balance
@@ -291,7 +289,7 @@ func balanceAndNonceAtTest(t *TestEnv) {
 		gasLimit = uint64(50000)
 	)
 	rawTx := types.NewTransaction(sourceNonce, targetAddr, amount, gasLimit, gasPrice, nil)
-	valueTx, err := t.Vault.signTransaction(sourceAddr, rawTx)
+	valueTx, err := t.Config.Vault.signTransaction(sourceAddr, rawTx)
 	if err != nil {
 		t.Fatalf("Unable to sign value tx: %v", err)
 	}

--- a/simulators/optimism/devnet/helper.go
+++ b/simulators/optimism/devnet/helper.go
@@ -29,7 +29,8 @@ type TestEnv struct {
 	Eth   *ethclient.Client
 	Vault *vault
 
-	genesis []byte
+	genesis              []byte
+	deployedContractAddr common.Address
 
 	// This holds most recent context created by the Ctx method.
 	// Every time Ctx is called, it creates a new context with the default
@@ -51,10 +52,10 @@ func runHTTP(t *hivesim.T, c *hivesim.Client, v *vault, g []byte, fn func(*TestE
 	rpcClient, _ := rpc.DialHTTPWithClient(fmt.Sprintf("http://%v:9545/", c.IP), client)
 	defer rpcClient.Close()
 	env := &TestEnv{
-		T:     t,
-		RPC:   rpcClient,
-		Eth:   ethclient.NewClient(rpcClient),
-		Vault: v,
+		T:       t,
+		RPC:     rpcClient,
+		Eth:     ethclient.NewClient(rpcClient),
+		Vault:   v,
 		genesis: g,
 	}
 	fn(env)
@@ -74,10 +75,10 @@ func runWS(t *hivesim.T, c *hivesim.Client, v *vault, g []byte, fn func(*TestEnv
 	defer rpcClient.Close()
 
 	env := &TestEnv{
-		T:     t,
-		RPC:   rpcClient,
-		Eth:   ethclient.NewClient(rpcClient),
-		Vault: v,
+		T:       t,
+		RPC:     rpcClient,
+		Eth:     ethclient.NewClient(rpcClient),
+		Vault:   v,
 		genesis: g,
 	}
 	fn(env)

--- a/simulators/optimism/devnet/main.go
+++ b/simulators/optimism/devnet/main.go
@@ -20,6 +20,7 @@ var tests = []testSpec{
 	// HTTP RPC tests.
 	{Name: "http/BalanceAndNonceAt", Run: balanceAndNonceAtTest},
 	{Name: "http/ContractDeployment", Run: deployContractTest},
+	{Name: "http/CodeAt", Run: CodeAtTest},
 	{Name: "http/ContractDeploymentOutOfGas", Run: deployContractOutOfGasTest},
 	{Name: "http/GenesisBlockByHash", Run: genesisBlockByHashTest},
 	{Name: "http/GenesisBlockByNumber", Run: genesisBlockByNumberTest},

--- a/simulators/optimism/devnet/main.go
+++ b/simulators/optimism/devnet/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"math/big"
 	"time"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -45,7 +43,6 @@ func setup(t *TestEnv) {
 	t.Logf("Deploy transaction: 0x%x", deployTx.Hash())
 
 	// fetch transaction receipt for contract address
-	var contractAddress common.Address
 	receipt, err := waitForTxConfirmations(t, deployTx.Hash(), 5)
 	if err != nil {
 		t.Fatalf("Unable to retrieve receipt: %v", err)
@@ -53,19 +50,10 @@ func setup(t *TestEnv) {
 
 	// ensure receipt has the expected address
 	if expectedContractAddress != receipt.ContractAddress {
-		t.Fatalf("Contract deploy on different address, expected %x, got %x", expectedContractAddress, contractAddress)
+		t.Fatalf("Contract deploy on different address, expected %x, got %x", expectedContractAddress, receipt.ContractAddress)
 	}
 
-	// test deployed code matches runtime code
-	code, err := t.Eth.CodeAt(t.Ctx(), receipt.ContractAddress, nil)
-	if err != nil {
-		t.Fatalf("Unable to fetch contract code: %v", err)
-	}
-	if bytes.Compare(runtimeCode, code) != 0 {
-		t.Errorf("Deployed code doesn't match, expected %x, got %x", runtimeCode, code)
-	}
-
-	t.Config.DeployedContractAddr = contractAddress
+	t.Config.DeployedContractAddr = receipt.ContractAddress
 }
 
 var tests = []testSpec{


### PR DESCRIPTION
Start restoring tests which depend on a pre-deploy address, replacing it with a newly deployed contract address. Might move the new deployment to a setup step outside the test suite to minimize dependency.