### PR TITLE
simulators (op): bump semaphore count

### DIFF
--- a/simulators/optimism/devnet/main.go
+++ b/simulators/optimism/devnet/main.go
@@ -109,7 +109,7 @@ func runAllTests(t *hivesim.T) {
 	vault := newVault()
 	genesis := []byte(d.l2Genesis)
 
-	s := newSemaphore(16)
+	s := newSemaphore(20)
 	for _, test := range tests {
 		test := test
 		s.get()


### PR DESCRIPTION
Bumps the default `semaphore` count which is used to parallelize the test runners. In this case we have 38 total tests which are roughly 19 each for `HTTP` and `WebSockets`, so 20 is a safe bet.