### PR TITLE
simulator (op): bump semaphore count (again)

### DIFF
--- a/simulators/optimism/devnet/main.go
+++ b/simulators/optimism/devnet/main.go
@@ -109,7 +109,7 @@ func runAllTests(t *hivesim.T) {
 	vault := newVault()
 	genesis := []byte(d.l2Genesis)
 
-	s := newSemaphore(20)
+	s := newSemaphore(40)
 	for _, test := range tests {
 		test := test
 		s.get()


### PR DESCRIPTION
Bumping the semaphore account, this time setting it high enough that lower core cpu doesn't throttle the parallelization.