### PR TITLE
clients (op): fix deploy - use proxy contracts

### DIFF
--- a/clients/op-l2/entrypoint.sh
+++ b/clients/op-l2/entrypoint.sh
@@ -9,7 +9,7 @@ function get_deployed_bytecode() {
 L1_BLOCK_INFO_BYTECODE=$(get_deployed_bytecode /L1Block.json)
 L2_TO_L1_MESSAGE_PASSER_BYTECODE=$(get_deployed_bytecode /L2ToL1MessagePasser.json)
 L2_CROSS_DOMAIN_MESSENGER_BYTECODE=$(get_deployed_bytecode /L2CrossDomainMessenger.json)
-OPTIMISM_MINTABLE_TOKEN_FACTORY_BYTECODE=$(get_deployed_bytecode /OptimismMintableTokenFactory.json)
+OPTIMISM_MINTABLE_TOKEN_FACTORY_BYTECODE=$(get_deployed_bytecode /OptimismMintableTokenFactoryProxy.json)
 L2_STANDARD_BRIDGE_BYTECODE=$(get_deployed_bytecode /L2StandardBridge.json)
 
 GENESIS_TIMESTAMP=$(cat /genesis_timestamp)

--- a/clients/op-proposer/entrypoint.sh
+++ b/clients/op-proposer/entrypoint.sh
@@ -11,7 +11,7 @@ curl \
     --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", false],"id":1}' \
     http://172.17.0.3:8545
 
-L2OO_ADDRESS=$(jq -r .address < /L2OutputOracle.json)
+L2OO_ADDRESS=$(jq -r .address < /L2OutputOracleProxy.json)
 
 exec op-proposer \
     --l1-eth-rpc http://172.17.0.3:8545 \


### PR DESCRIPTION
Updated contracts to be proxies. Fixes deployment of `op-l2` and `op-proposer`.