### PR TITLE
simulator (op/rpc): bump reference-optimistic-geth

### DIFF
--- a/simulators/optimism/rpc/go.mod
+++ b/simulators/optimism/rpc/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/hive/simulators/optimism/rpc
 
 go 1.18
 
-replace github.com/ethereum/go-ethereum v1.10.17 => github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220616183505-9a67f31e4592
+replace github.com/ethereum/go-ethereum v1.10.17 => github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220701172458-eb7063ffd498
 
 require (
 	github.com/ethereum-optimism/hive/simulators/optimism/devnet v0.0.0-20220629174645-706bb72bc224

--- a/simulators/optimism/rpc/go.sum
+++ b/simulators/optimism/rpc/go.sum
@@ -100,6 +100,8 @@ github.com/ethereum-optimism/optimism/op-bindings v0.0.0-20220614233543-0d8fa52a
 github.com/ethereum-optimism/optimism/op-bindings v0.0.0-20220614233543-0d8fa52afca2/go.mod h1:e9mMYiVsdJf9BI//FdaA77BwNNgNMR043JtB7CPXNxY=
 github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220616183505-9a67f31e4592 h1:o0iObEB8uMXiu0XdeODWsqbg5MSNhsFoM/a37szPVXs=
 github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220616183505-9a67f31e4592/go.mod h1:8AfU1epKggKxDt9wr7rH5KmCeiT3yT0sEvroru1mO6Q=
+github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220701172458-eb7063ffd498 h1:kuLbouVCJR/w+SEJR0k6roHcZGWzRzJ7B3K2DxlxQ/0=
+github.com/ethereum-optimism/reference-optimistic-geth v0.0.0-20220701172458-eb7063ffd498/go.mod h1:8AfU1epKggKxDt9wr7rH5KmCeiT3yT0sEvroru1mO6Q=
 github.com/ethereum/hive v0.0.0-20220630112103-4b22dc796d94 h1:39Oo8ybna0qHaFAdrZi+PHdZptqtijuF/B3nKcNnTr0=
 github.com/ethereum/hive v0.0.0-20220630112103-4b22dc796d94/go.mod h1:vQuqye6Z1jGIfm+KietrneQ+LTZUJ8imipAq7tMGvV0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
Bumps `reference-optimistic-geth` to handle deposit tx hash.

https://github.com/ethereum-optimism/reference-optimistic-geth/pull/30