### PR TITLE
op: refactor op-node to use dynamic hive.Params

### DIFF
--- a/clients/op-batcher/entrypoint.sh
+++ b/clients/op-batcher/entrypoint.sh
@@ -1,29 +1,12 @@
 #!/bin/sh
 set -exu
 
-# Generate the bss config.
-
-L2_URL="http://172.17.0.4:9545"
-
-# Grab the L2 genesis. We can use cURL here to retry.
-L2_GENESIS=$(curl \
-    --silent \
-    --fail \
-    --retry 10 \
-    --retry-delay 2 \
-    --retry-connrefused \
-    -X POST \
-    -H "Content-Type: application/json" \
-    --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", false],"id":1}' \
-    $L2_URL)
-
-SEQUENCER_GENESIS_HASH="$(echo $L2_GENESIS | jq -r '.result.hash')"
 SEQUENCER_BATCH_INBOX_ADDRESS="$(cat /rollup.json | jq -r '.batch_inbox_address')"
 
 exec op-batcher \
-    --l1-eth-rpc=http://172.17.0.3:8545 \
-    --l2-eth-rpc=http://172.17.0.4:9545 \
-    --rollup-rpc=http://172.17.0.5:7545 \
+    $HIVE_L1_ETH_RPC_FLAG \
+    $HIVE_L2_ETH_RPC_FLAG \
+    $HIVE_ROLLUP_RPC_FLAG \
     --min-l1-tx-size-bytes=1 \
     --max-l1-tx-size-bytes=120000 \
     --channel-timeout=40 \

--- a/clients/op-node/hive.yaml
+++ b/clients/op-node/hive.yaml
@@ -1,2 +1,3 @@
 roles:
   - "op-node"
+  - "op-sequencer"

--- a/clients/op-node/opnode-entrypoint.sh
+++ b/clients/op-node/opnode-entrypoint.sh
@@ -41,10 +41,10 @@ exec op-node \
     --l1=ws://172.17.0.3:8546 \
     --l2=ws://172.17.0.4:9546 \
     --l2.jwt-secret=/config/test-jwt-secret.txt \
-    --sequencer.enabled \
+    $HIVE_SEQUENCER_ENABLED_FLAG \
     --sequencer.l1-confs=0 \
     --verifier.l1-confs=0 \
-    --p2p.sequencer.key=/config/p2p-sequencer-key.txt \
+    $HIVE_SEQUENCER_KEY_FLAG \
     --rollup.config=/hive/rollup.json \
     --rpc.addr=0.0.0.0 \
     --rpc.port=7545 \

--- a/clients/op-node/opnode-entrypoint.sh
+++ b/clients/op-node/opnode-entrypoint.sh
@@ -3,9 +3,6 @@ set -exu
 
 # Generate the rollup config.
 
-L1_URL="http://172.17.0.3:8545"
-L2_URL="http://172.17.0.4:9545"
-
 # Grab the L1 genesis. We can use cURL here to retry.
 L1_GENESIS=$(curl \
     --silent \
@@ -16,7 +13,7 @@ L1_GENESIS=$(curl \
     -X POST \
     -H "Content-Type: application/json" \
     --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", false],"id":1}' \
-    $L1_URL)
+    $HIVE_L1_URL)
 
 # Grab the L2 genesis. We can use cURL here to retry.
 L2_GENESIS=$(curl \
@@ -28,7 +25,7 @@ L2_GENESIS=$(curl \
     -X POST \
     -H "Content-Type: application/json" \
     --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", false],"id":1}' \
-    $L2_URL)
+    $HIVE_L2_URL)
 
 DEPOSIT_CONTRACT_ADDRESS=$(jq -r .address < /OptimismPortalProxy.json)
 
@@ -38,13 +35,13 @@ jq ". | .genesis.l1.hash = \"$(echo $L1_GENESIS | jq -r '.result.hash')\"" < /ro
    jq ". | .deposit_contract_address = \"$DEPOSIT_CONTRACT_ADDRESS\"" > /hive/rollup.json
 
 exec op-node \
-    --l1=ws://172.17.0.3:8546 \
-    --l2=ws://172.17.0.4:9546 \
+    $HIVE_L1_ETH_RPC_FLAG \
+    $HIVE_L2_ENGINE_RPC_FLAG \
     --l2.jwt-secret=/config/test-jwt-secret.txt \
     $HIVE_SEQUENCER_ENABLED_FLAG \
+    $HIVE_SEQUENCER_KEY_FLAG \
     --sequencer.l1-confs=0 \
     --verifier.l1-confs=0 \
-    $HIVE_SEQUENCER_KEY_FLAG \
     --rollup.config=/hive/rollup.json \
     --rpc.addr=0.0.0.0 \
     --rpc.port=7545 \

--- a/clients/op-proposer/entrypoint.sh
+++ b/clients/op-proposer/entrypoint.sh
@@ -1,22 +1,12 @@
 #!/bin/sh
 set -exu
 
-curl \
-    --fail \
-    --retry 10 \
-    --retry-delay 2 \
-    --retry-connrefused \
-    -X POST \
-    -H "Content-Type: application/json" \
-    --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", false],"id":1}' \
-    http://172.17.0.3:8545
-
 L2OO_ADDRESS=$(jq -r .address < /L2OutputOracleProxy.json)
 
 exec op-proposer \
-    --l1-eth-rpc http://172.17.0.3:8545 \
-    --l2-eth-rpc http://172.17.0.4:9545 \
-    --rollup-rpc http://172.17.0.5:7545 \
+    $HIVE_L1_ETH_RPC_FLAG \
+    $HIVE_L2_ETH_RPC_FLAG \
+    $HIVE_ROLLUP_RPC_FLAG \
     --poll-interval 10s \
     --num-confirmations 1 \
     --safe-abort-nonce-too-low-count 3 \

--- a/simulators/optimism/rpc/devnet.go
+++ b/simulators/optimism/rpc/devnet.go
@@ -234,38 +234,46 @@ func (d *Devnet) StartOp() error {
 
 	optimismPortalOpt := hivesim.WithDynamicFile("/OptimismPortalProxy.json", bytesSource([]byte(d.optimismPortal)))
 	opts := []hivesim.StartOption{executionOpts, optimismPortalOpt}
-	d.op = &OpNode{d.t.StartClient(op.Name, opts...)}
+	d.op = &OpNode{d.t.StartClient(op.Name, opts...), 7545}
 	return nil
 }
 
 func (d *Devnet) StartL2OS() error {
-	op := d.nodes["op-proposer"]
+	l2os := d.nodes["op-proposer"]
 
 	executionOpts := hivesim.Params{
 		"HIVE_CHECK_LIVE_PORT":  "0",
 		"HIVE_CATALYST_ENABLED": "1",
 		"HIVE_LOGLEVEL":         os.Getenv("HIVE_LOGLEVEL"),
 		"HIVE_NODETYPE":         "full",
+
+		"HIVE_L1_ETH_RPC_FLAG": fmt.Sprintf("--l1-eth-rpc=http://%s:%d", d.eth1.IP, d.eth1.HTTPPort),
+		"HIVE_L2_ETH_RPC_FLAG": fmt.Sprintf("--l2-eth-rpc=http://%s:%d", d.l2.IP, d.l2.HTTPPort),
+		"HIVE_ROLLUP_RPC_FLAG": fmt.Sprintf("--rollup-rpc=http://%s:%d", d.op.IP, d.op.HTTPPort),
 	}
 
 	l2OutputOracleOpt := hivesim.WithDynamicFile("/L2OutputOracleProxy.json", bytesSource([]byte(d.l2OutputOracle)))
 	opts := []hivesim.StartOption{executionOpts, l2OutputOracleOpt}
-	d.op = &OpNode{d.t.StartClient(op.Name, opts...)}
+	d.l2os = &L2OSNode{d.t.StartClient(l2os.Name, opts...)}
 	return nil
 }
 
 func (d *Devnet) StartBSS() error {
-	op := d.nodes["op-batcher"]
+	bss := d.nodes["op-batcher"]
 
 	executionOpts := hivesim.Params{
 		"HIVE_CHECK_LIVE_PORT":  "0",
 		"HIVE_CATALYST_ENABLED": "1",
 		"HIVE_LOGLEVEL":         os.Getenv("HIVE_LOGLEVEL"),
 		"HIVE_NODETYPE":         "full",
+
+		"HIVE_L1_ETH_RPC_FLAG": fmt.Sprintf("--l1-eth-rpc=http://%s:%d", d.eth1.IP, d.eth1.HTTPPort),
+		"HIVE_L2_ETH_RPC_FLAG": fmt.Sprintf("--l2-eth-rpc=http://%s:%d", d.l2.IP, d.l2.HTTPPort),
+		"HIVE_ROLLUP_RPC_FLAG": fmt.Sprintf("--rollup-rpc=http://%s:%d", d.op.IP, d.op.HTTPPort),
 	}
 
 	optimismPortalOpt := hivesim.WithDynamicFile("/OptimismPortalProxy.json", bytesSource([]byte(d.optimismPortal)))
 	opts := []hivesim.StartOption{executionOpts, optimismPortalOpt}
-	d.op = &OpNode{d.t.StartClient(op.Name, opts...)}
+	d.bss = &BSSNode{d.t.StartClient(bss.Name, opts...)}
 	return nil
 }

--- a/simulators/optimism/rpc/devnet.go
+++ b/simulators/optimism/rpc/devnet.go
@@ -222,6 +222,11 @@ func (d *Devnet) StartOp() error {
 		"HIVE_NODETYPE":         "full",
 	}
 
+	if op.HasRole("op-sequencer") {
+		executionOpts = executionOpts.Set("HIVE_SEQUENCER_ENABLED_FLAG", "--sequencer.enabled")
+		executionOpts = executionOpts.Set("HIVE_SEQUENCER_KEY_FLAG", "--p2p.sequencer.key=/config/p2p-sequencer-key.txt")
+	}
+
 	optimismPortalOpt := hivesim.WithDynamicFile("/OptimismPortalProxy.json", bytesSource([]byte(d.optimismPortal)))
 	opts := []hivesim.StartOption{executionOpts, optimismPortalOpt}
 	d.op = &OpNode{d.t.StartClient(op.Name, opts...)}

--- a/simulators/optimism/rpc/devnet.go
+++ b/simulators/optimism/rpc/devnet.go
@@ -99,7 +99,7 @@ func (d *Devnet) Start() {
 	executionOpts := hivesim.Bundle(eth1ConfigOpt, eth1Bundle, execNodeOpts)
 
 	opts := []hivesim.StartOption{executionOpts}
-	d.eth1 = &Eth1Node{d.t.StartClient(eth1.Name, opts...)}
+	d.eth1 = &Eth1Node{d.t.StartClient(eth1.Name, opts...), 8545, 8546}
 
 	d.nodes["op-l1"] = eth1
 	d.nodes["op-l2"] = l2
@@ -199,7 +199,7 @@ func (d *Devnet) StartL2() error {
 	l2StandardBridgeOpt := hivesim.WithDynamicFile("/L2StandardBridge.json", bytesSource([]byte(d.l2StandardBridgeJSON)))
 	l1BlockOpt := hivesim.WithDynamicFile("/L1Block.json", bytesSource([]byte(d.l1BlockJSON)))
 	opts := []hivesim.StartOption{executionOpts, genesisTimestampOpt, l2ToL1MessagePasserOpt, l2CrossDomainMessengerOpt, optimismMintableTokenFactoryOpt, l2StandardBridgeOpt, l1BlockOpt}
-	d.l2 = &L2Node{d.t.StartClient(l2.Name, opts...)}
+	d.l2 = &L2Node{d.t.StartClient(l2.Name, opts...), 9545, 9546}
 	return nil
 }
 
@@ -220,6 +220,11 @@ func (d *Devnet) StartOp() error {
 		"HIVE_CATALYST_ENABLED": "1",
 		"HIVE_LOGLEVEL":         os.Getenv("HIVE_LOGLEVEL"),
 		"HIVE_NODETYPE":         "full",
+
+		"HIVE_L1_URL":             fmt.Sprintf("http://%s:%d", d.eth1.IP, d.eth1.HTTPPort),
+		"HIVE_L2_URL":             fmt.Sprintf("http://%s:%d", d.l2.IP, d.l2.HTTPPort),
+		"HIVE_L1_ETH_RPC_FLAG":    fmt.Sprintf("--l1=ws://%s:%d", d.eth1.IP, d.eth1.WSPort),
+		"HIVE_L2_ENGINE_RPC_FLAG": fmt.Sprintf("--l2=ws://%s:%d", d.l2.IP, d.l2.WSPort),
 	}
 
 	if op.HasRole("op-sequencer") {

--- a/simulators/optimism/rpc/nodes.go
+++ b/simulators/optimism/rpc/nodes.go
@@ -4,10 +4,14 @@ import "github.com/ethereum/hive/hivesim"
 
 type Eth1Node struct {
 	*hivesim.Client
+	HTTPPort uint16
+	WSPort   uint16
 }
 
 type L2Node struct {
 	*hivesim.Client
+	HTTPPort uint16
+	WSPort   uint16
 }
 
 type OpNode struct {

--- a/simulators/optimism/rpc/nodes.go
+++ b/simulators/optimism/rpc/nodes.go
@@ -16,6 +16,7 @@ type L2Node struct {
 
 type OpNode struct {
 	*hivesim.Client
+	HTTPPort uint16
 }
 
 type L2OSNode struct {


### PR DESCRIPTION
`op-node` client right now is configured as a sequencer and it's hard to launch a verifier node from it, without duplicating a lot of code.

This PR refactors the `op-node` to make it dynamically configurable as either a `op-sequencer` or a verifier `op-node`.

Later this separation can be used to implement p2p tests without duplicating a lot of code for sequencer and verifier clients.

While here, we also clean up some hardcoded IP addresses, ports and keys.

Fixes ENG-2469.