### PR TITLE
ci: Use image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           command: |
             /tmp/build/hive \
-            -sim='optimism/*' \
+            -sim=optimism \
             -sim.loglevel=5 \
             -docker.pull=true \
             -client=go-ethereum,op-geth_optimism-history,op-proposer_develop,op-batcher_develop,op-node_develop,op-contracts_develop |& tee /tmp/build/hive.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,24 @@ jobs:
   hive-optimism-tests:
     machine:
       image: ubuntu-2004:202201-02
+      docker_layer_caching: true
     steps:
       - checkout
       - attach_workspace: {at: "/tmp/build"}
       - run:
-          command: "/tmp/build/hive -sim=\"optimism/*\" -sim.loglevel=5 -client=go-ethereum,op-geth,op-proposer,op-batcher,op-node,op-contracts |& tee /tmp/build/hive.log"
+          command: |
+            /tmp/build/hive \
+            -sim='optimism/*' \
+            -sim.loglevel=5 \
+            -docker.pull=true \
+            -client=go-ethereum,op-geth_optimism-history,op-proposer_develop,op-batcher_develop,op-node_develop,op-contracts_develop |& tee /tmp/build/hive.log
+      - run:
+          command: |
+            tar -cvf /tmp/workspace.tgz -C /home/circleci/project /home/circleci/project/workspace
+          name: "Archive workspace"
+      - store_artifacts:
+          path: /tmp/workspace.tgz
+          destination: hive-workspace.tgz
       - run:
           command: "! grep 'pass.*=false' /tmp/build/hive.log"
       - slack/notify:
@@ -69,6 +82,19 @@ workflows:
   main:
     jobs:
       - go-test
+      - build
+      - hive-optimism-tests:
+          requires: ["build"]
+          context: slack
+  scheduled:
+    triggers:
+      - schedule:
+          # run every 4 hours
+          cron: "0 0,4,8,12,16 * * *"
+          filters:
+            branches:
+              only: [ "optimism" ]
+    jobs:
       - build
       - hive-optimism-tests:
           requires: ["build"]

--- a/clients/op-batcher/Dockerfile
+++ b/clients/op-batcher/Dockerfile
@@ -1,23 +1,11 @@
-FROM golang:1.18.0-alpine3.15 as builder
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
 ARG branch=develop
-
-RUN git clone -b $branch https://github.com/ethereum-optimism/optimism /app
-
-WORKDIR /app/op-batcher
-RUN make op-batcher
-
-FROM alpine:3.15
+FROM us-central1-docker.pkg.dev/bedrock-goerli-development/images/op-batcher:$branch
 
 RUN apk add curl jq bash
 RUN apk add --no-cache ca-certificates
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
-COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin
 
 RUN op-batcher --version 2>/dev/null | head -1 > /version.txt
 

--- a/clients/op-contracts/Dockerfile
+++ b/clients/op-contracts/Dockerfile
@@ -1,21 +1,9 @@
-FROM ethereumoptimism/ci-builder:latest
+ARG branch=develop
+FROM us-central1-docker.pkg.dev/bedrock-goerli-development/images/deployer-bedrock:$branch
 
 RUN npm install http-server -g
 
-ADD install_foundry.sh /install_foundry.sh
-RUN chmod +x /install_foundry.sh && /bin/bash /install_foundry.sh
-
-ARG branch=develop
-# Git clone Optimism monorepo
-RUN git clone -b $branch https://github.com/ethereum-optimism/optimism /hive/optimism
-
-RUN cd /hive/optimism && git rev-parse HEAD > /version.txt
-
-# download submodules, so container does not have to at startup
-RUN cd /hive/optimism && git submodule init && git submodule update
-
-# build the monorepo typescript part
-RUN cd /hive/optimism && make build-ts
+RUN echo $branch > /version.txt
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/clients/op-contracts/entrypoint.sh
+++ b/clients/op-contracts/entrypoint.sh
@@ -4,4 +4,4 @@ echo "starting op-contracts"
 
 # this web-browser will keep ensure the container is considered ready and alive by Hive,
 # and make it easy to navigate the live container contents.
-http-server -p 8545 -d -i -a 0.0.0.0 /hive/optimism > /dev/null
+http-server -p 8545 -d -i -a 0.0.0.0 /opt/optimism > /dev/null

--- a/clients/op-contracts/install_foundry.sh
+++ b/clients/op-contracts/install_foundry.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-curl -L https://foundry.paradigm.xyz | bash
-source $HOME/.bashrc
-foundryup
-echo "" >> $HOME/.bashrc
-echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $HOME/.bashrc

--- a/clients/op-contracts/scripts/config_l1.sh
+++ b/clients/op-contracts/scripts/config_l1.sh
@@ -2,9 +2,9 @@
 
 set -eu
 
-cd /hive/optimism/packages/contracts-bedrock
+cd /opt/optimism/packages/contracts-bedrock
 
 # generate L1 config, redirect standard output to stderr, we output the result as json to stdout later
-npx hardhat --network hivenet genesis-l1 --l1-genesis-block-timestamp $1 --outfile genesis-l1.json 1>&2
+npx hardhat --network hivenet genesis-l1 --outfile genesis-l1.json 1>&2
 
 cat genesis-l1.json

--- a/clients/op-contracts/scripts/config_l2.sh
+++ b/clients/op-contracts/scripts/config_l2.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cd /hive/optimism/packages/contracts-bedrock
+cd /opt/optimism/packages/contracts-bedrock
 
 # we use the L1 RPC to fetch L1 block info in hardhat
 export L1_RPC="$1"

--- a/clients/op-contracts/scripts/config_rollup.sh
+++ b/clients/op-contracts/scripts/config_rollup.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cd /hive/optimism/packages/contracts-bedrock
+cd /opt/optimism/packages/contracts-bedrock
 
 # we use the L1 RPC to fetch L1 block info in hardhat
 export L1_RPC="$1"

--- a/clients/op-contracts/scripts/deploy_config.sh
+++ b/clients/op-contracts/scripts/deploy_config.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cd /hive/optimism/packages/contracts-bedrock
+cd /opt/optimism/packages/contracts-bedrock
 
 # Deploy config is provided as first script argument
 echo "$1" > deploy-config/hivenet.json

--- a/clients/op-contracts/scripts/deploy_l1.sh
+++ b/clients/op-contracts/scripts/deploy_l1.sh
@@ -8,11 +8,7 @@ echo "configuring rollup config using L1 RPC: $L1_RPC" 1>&2
 export PRIVATE_KEY_DEPLOYER="$2"
 export CHAIN_ID="$3"
 
-yarn global add npx -W 2>&1
-cd /hive/optimism
-yarn 2>&1
-yarn build 2>&1
-cd /hive/optimism/packages/contracts-bedrock
+cd /opt/optimism/packages/contracts-bedrock
 
 forge --version
 yarn hardhat --network hivenet deploy 2>&1

--- a/clients/op-contracts/scripts/deployments.sh
+++ b/clients/op-contracts/scripts/deployments.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-cd /hive/optimism/packages/contracts-bedrock/deployments/hivenet/
+cd /opt/optimism/packages/contracts-bedrock/deployments/hivenet/
 # This combines all deployment objects into a single json object, keyed by contract name (file name stripped from .json)
 jq -n 'reduce inputs as $s (.; .[input_filename|rtrimstr(".json")|ltrimstr("./")] += $s)' ./* || true

--- a/clients/op-geth/Dockerfile
+++ b/clients/op-geth/Dockerfile
@@ -1,22 +1,8 @@
-# Build Geth in a stock Go builder container
-FROM golang:1.18-alpine as builder
-
-RUN apk add --no-cache gcc musl-dev linux-headers git
-
-ARG branch=optimism
-
-RUN git clone -b $branch https://github.com/ethereum-optimism/reference-optimistic-geth /go-ethereum
-
-RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
-
-# Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+ARG branch=develop
+FROM ethereumoptimism/reference-optimistic-geth:$branch
 
 RUN apk add curl jq bash
 RUN apk add --no-cache ca-certificates
-
-COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
-
 RUN geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
 
 ADD entrypoint.sh /entrypoint.sh

--- a/clients/op-node/Dockerfile
+++ b/clients/op-node/Dockerfile
@@ -1,20 +1,8 @@
-FROM golang:1.18.0-alpine3.15 as builder
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
 ARG branch=develop
-
-RUN git clone -b $branch https://github.com/ethereum-optimism/optimism /app
-
-WORKDIR /app/op-node
-RUN make op-node
-
-FROM alpine:3.15
+FROM us-central1-docker.pkg.dev/bedrock-goerli-development/images/op-node:$branch
 
 RUN apk add curl jq bash
 RUN apk add --no-cache ca-certificates
-
-COPY --from=builder /app/op-node/bin/op-node /usr/local/bin
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/clients/op-proposer/Dockerfile
+++ b/clients/op-proposer/Dockerfile
@@ -1,23 +1,11 @@
-FROM golang:1.18.0-alpine3.15 as builder
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
 ARG branch=develop
-
-RUN git clone -b $branch https://github.com/ethereum-optimism/optimism /app
-
-WORKDIR /app/op-proposer
-RUN make
-
-FROM alpine:3.15
+FROM us-central1-docker.pkg.dev/bedrock-goerli-development/images/op-proposer:$branch
 
 RUN apk add curl jq bash
 RUN apk add --no-cache ca-certificates
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
-COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin
 
 RUN op-proposer --version 2>/dev/null | head -1 > /version.txt
 

--- a/optimism/helper.go
+++ b/optimism/helper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/hive/hivesim"
 	"io"
 	"io/ioutil"
+	"strings"
 )
 
 func bytesFile(name string, data []byte) hivesim.StartOption {
@@ -21,6 +22,9 @@ func stringFile(name string, data string) hivesim.StartOption {
 var defaultJWTPath = "/hive/input/jwt-secret.txt"
 var defaultJWTSecret = common.Hash{42}
 var defaultJWTFile = stringFile(defaultJWTPath, defaultJWTSecret.String())
+var defaultP2PSequencerKeyPath = "/hive/input/p2p-sequencer-key.txt"
+var defaultP2PSequencerKey = common.Hash{32}
+var defaultP2pSequencerKeyFile = stringFile(defaultP2PSequencerKeyPath, strings.Replace(defaultP2PSequencerKey.Hex(), "0x", "", 1))
 
 // HiveUnpackParams are hivesim.Params that have yet to be prefixed with "HIVE_UNPACK_".
 //

--- a/simulators/optimism/p2p/main.go
+++ b/simulators/optimism/p2p/main.go
@@ -36,20 +36,20 @@ func runP2PTests(t *hivesim.T) {
 	d := optimism.NewDevnet(t)
 
 	d.InitContracts()
-	d.InitHardhatDeployConfig(10, 4, 30)
+	d.InitHardhatDeployConfig("earliest", 10, 4, 30)
 	d.InitL1Hardhat()
 	d.AddEth1() // l1 eth1 node is required for l2 config init
 	d.WaitUpEth1(0, time.Second*10)
 	// deploy contracts
 	d.DeployL1Hardhat()
 
-	d.InitL2Hardhat()
+	d.InitL2Hardhat(nil)
 	d.AddOpL2() // l2 engine is required for rollup config init
 	d.WaitUpOpL2Engine(0, time.Second*10)
 	d.InitRollupHardhat()
 
 	// sequencer stack, on top of first eth1 node
-	d.AddOpNode(0, 0)
+	d.AddOpNode(0, 0, true)
 	d.AddOpBatcher(0, 0, 0)
 	d.AddOpProposer(0, 0, 0)
 
@@ -58,11 +58,11 @@ func runP2PTests(t *hivesim.T) {
 
 	// verifier A
 	d.AddOpL2()
-	d.AddOpNode(0, 1) // we attach to the same L1 node, so we don't need to configure L1 networking.
+	d.AddOpNode(0, 1, false) // we attach to the same L1 node, so we don't need to configure L1 networking.
 
 	// verifier B
 	d.AddOpL2()
-	d.AddOpNode(0, 2)
+	d.AddOpNode(0, 2, false)
 
 	t.Log("waiting for nodes to get onto the network")
 

--- a/simulators/optimism/testnet/main.go
+++ b/simulators/optimism/testnet/main.go
@@ -38,20 +38,20 @@ func runTestnet(t *hivesim.T) {
 	d := optimism.NewDevnet(t)
 
 	d.InitContracts()
-	d.InitHardhatDeployConfig(10, 4, 30)
+	d.InitHardhatDeployConfig("earliest", 10, 4, 30)
 	d.InitL1Hardhat()
 	d.AddEth1() // l1 eth1 node is required for l2 config init
 	d.WaitUpEth1(0, time.Second*10)
 	// deploy contracts
 	d.DeployL1Hardhat()
 
-	d.InitL2Hardhat()
+	d.InitL2Hardhat(nil)
 	d.AddOpL2() // l2 engine is required for rollup config init
 	d.WaitUpOpL2Engine(0, time.Second*10)
 	d.InitRollupHardhat()
 
 	// sequencer stack, on top of first eth1 node
-	d.AddOpNode(0, 0)
+	d.AddOpNode(0, 0, true)
 	d.AddOpBatcher(0, 0, 0)
 	d.AddOpProposer(0, 0, 0)
 
@@ -60,11 +60,11 @@ func runTestnet(t *hivesim.T) {
 
 	// verifier A
 	d.AddOpL2()
-	d.AddOpNode(0, 1) // we attach to the same L1 node, so we don't need to configure L1 networking.
+	d.AddOpNode(0, 1, false) // we attach to the same L1 node, so we don't need to configure L1 networking.
 
 	// verifier B
 	d.AddOpL2()
-	d.AddOpNode(0, 2)
+	d.AddOpNode(0, 2, false)
 
 	t.Log("waiting for nodes to get onto the network")
 


### PR DESCRIPTION
Previously, Hive compiled all the Optimism dependencies from scratch. Now that we have Cloud Build in place for the monorepo and per-commit builds in place for reference-optimistic-geth, we can switch Hive to pull images. This is significantly faster than compilation.

This PR also updates CircleCI to upload Hive's workspace upon completion in order to enable easier debugging.

Depends on https://github.com/ethereum-optimism/reference-optimistic-geth/pull/44.