### PR TITLE
optimism: use engine api endpoint, not regular endpoint

### DIFF
--- a/optimism/devnet.go
+++ b/optimism/devnet.go
@@ -183,7 +183,7 @@ func (d *Devnet) AddOpNode(eth1Index int, l2EngIndex int, sequencer bool, opts .
 	}
 	defaultSettings := HiveUnpackParams{
 		opnf.L1NodeAddr.EnvVar:           eth1Node.WsRpcEndpoint(),
-		opnf.L2EngineAddr.EnvVar:         l2Engine.WsRpcEndpoint(),
+		opnf.L2EngineAddr.EnvVar:         l2Engine.EngineEndpoint(),
 		opnf.RollupConfig.EnvVar:         "/rollup_config.json",
 		opnf.RPCListenAddr.EnvVar:        "0.0.0.0",
 		opnf.RPCListenPort.EnvVar:        fmt.Sprintf("%d", RollupRPCPort),

--- a/optimism/nodes.go
+++ b/optimism/nodes.go
@@ -29,6 +29,10 @@ func (e *ELNode) HttpRpcEndpoint() string {
 	return fmt.Sprintf("http://%v:%d", e.IP, HttpRPCPort)
 }
 
+func (e *ELNode) EngineEndpoint() string {
+	return fmt.Sprintf("ws://%v:%d", e.IP, EnginePort)
+}
+
 func (e *ELNode) WsRpcEndpoint() string {
 	// carried over from older mergenet ws connection problems, idk why clients are different
 	switch e.Client.Type {


### PR DESCRIPTION
Use the engine API endpoint, not the engine API that is exposed on the user endpoint.