### PR TITLE
Improve withdrawal reliability, parallelize tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,17 +23,22 @@ jobs:
   # The below job runs the optimism test simulations. This requires a virtual
   # machine instead of the container-based build environment because hive needs
   # to be able to talk to the docker containers it creates.
-  hive-optimism-tests:
+  run-hive-sim:
     machine:
       image: ubuntu-2004:202201-02
       docker_layer_caching: true
+    parameters:
+      sim:
+        type: string
+        default: optimism
+        description: Sims to run
     steps:
       - checkout
       - attach_workspace: {at: "/tmp/build"}
       - run:
           command: |
             /tmp/build/hive \
-            -sim=optimism \
+            -sim=<<parameters.sim>> \
             -sim.loglevel=5 \
             -docker.pull=true \
             -client=go-ethereum,op-geth_optimism-history,op-proposer_develop,op-batcher_develop,op-node_develop |& tee /tmp/build/hive.log || echo "failed."
@@ -83,9 +88,26 @@ workflows:
     jobs:
       - go-test
       - build
-      - hive-optimism-tests:
+      - run-hive-sim:
+          name: hive-test-l1ops
           requires: ["build"]
           context: slack
+          sim: optimism/l1ops
+      - run-hive-sim:
+          name: hive-test-p2p
+          requires: [ "build" ]
+          context: slack
+          sim: optimism/p2p
+      - run-hive-sim:
+          name: hive-test-rpc
+          requires: [ "build" ]
+          context: slack
+          sim: optimism/rpc
+      - run-hive-sim:
+          name: hive-test-testnet
+          requires: [ "build" ]
+          context: slack
+          sim: optimism/testnet
   scheduled:
     triggers:
       - schedule:
@@ -96,6 +118,6 @@ workflows:
               only: [ "optimism" ]
     jobs:
       - build
-      - hive-optimism-tests:
+      - run-hive-sim:
           requires: ["build"]
           context: slack

--- a/clients/op-geth/entrypoint.sh
+++ b/clients/op-geth/entrypoint.sh
@@ -19,10 +19,13 @@ else
 	echo "$GETH_CHAINDATA_DIR exists."
 fi
 
+# We must set miner.gaslimit to the gas limit in genesis
+# in the command below!
+GAS_LIMIT_HEX=$(jq -r .gasLimit < /genesis.json | sed s/0x//i | tr '[:lower:]' '[:upper:]')
+GAS_LIMIT=$(echo "obase=10; ibase=16; $GAS_LIMIT_HEX" | bc)
+
 # Warning: Archive mode is required, otherwise old trie nodes will be
 # pruned within minutes of starting the devnet.
-
-# TODO: increase max peers, enable p2p, once we get to snap sync testing in Hive.
 
 geth \
 	--datadir="$GETH_DATA_DIR" \
@@ -44,8 +47,10 @@ geth \
 	--syncmode=full \
 	--nodiscover \
 	--maxpeers=0 \
+	--miner.gaslimit=$GAS_LIMIT \
 	--networkid="$CHAIN_ID" \
 	--password="$GETH_DATA_DIR"/password \
 	--allow-insecure-unlock \
 	--gcmode=archive \
+	--rollup.disabletxpoolgossip=true \
 	"$@"

--- a/simulators/optimism/l1ops/main.go
+++ b/simulators/optimism/l1ops/main.go
@@ -40,8 +40,8 @@ func runAllTests(tests []*optimism.TestSpec) func(t *hivesim.T) {
 
 		d := optimism.NewDevnet(t)
 		require.NoError(t, optimism.StartSequencerDevnet(ctx, d, &optimism.SequencerDevnetParams{
-			MaxSeqDrift:   10,
-			SeqWindowSize: 4,
+			MaxSeqDrift:   120,
+			SeqWindowSize: 120,
 			ChanTimeout:   30,
 		}))
 


### PR DESCRIPTION
The `--miner.gaslimit` flag was not being passed, which could lead to reorgs. I also increased the max sequencer drift and sequencing window to match the devnet.

Lastly, I parallelized the hive tests so that they finish more quickly and upload artifacts belonging to a single simulator. This makes debugging easier, and was necessary for me to figure out what was happening here.

Fixes ENG-2726