### PR TITLE
Attempt to fix deposit/withdrawal tests

### DIFF
--- a/optimism/devnet.go
+++ b/optimism/devnet.go
@@ -519,17 +519,12 @@ func StartSequencerDevnet(ctx context.Context, d *Devnet, params *SequencerDevne
 	d.AddOpBatcher(0, 0, 0)
 	d.AddOpProposer(0, 0, 0)
 
-	block, err := d.L1Client(0).BlockByNumber(ctx, nil)
-	if err != nil {
-		return err
-	}
-	expHeight := uint64(time.Now().Sub(time.Unix(int64(block.Time()), 0)).Seconds() / 2)
-	if err := WaitBlock(ctx, d.L2Client(0), expHeight); err != nil {
-		return err
-	}
-
 	d.InitBindingsL1(0)
 	d.InitBindingsL2(0)
+
+	if err := WaitBlock(ctx, d.L1Client(0), 2); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
I narrowed this issue down to reverts during deposits. It seems like the default gas limit calculation under-estimates the limit sometimes which leads to deposits reverting without a reason. I'm not 100% sure why this is, but I have a hunch it's related to the `ResourceMetering` contract since specifying a high manual gas limit resolved the issue. I'll follow up with @tynes to dig deeper into whether this is correct, and understand the root cause.

To test this, I ran the tests 3 times against CI and got passes each time.

I also updated the `WaitReceipt` helper to properly check the status of each transaction.

Fixes ENG-2726
