### PR TITLE
Remove `op-contracts` client from readmes

### DIFF
--- a/simulators/optimism/l1ops/README.md
+++ b/simulators/optimism/l1ops/README.md
@@ -1,0 +1,5 @@
+# Hive Optimism L1 Ops test suite
+
+This test suite tests the deposits & withdrawals functionality in an Optimism Bedrock testnet.
+
+    hive --sim optimism/l1ops --client=go-ethereum,op-geth,op-proposer,op-batcher,op-node --docker.output

--- a/simulators/optimism/p2p/README.md
+++ b/simulators/optimism/p2p/README.md
@@ -2,4 +2,4 @@
 
 This test suite tests the P2P functionality in an Optimism Bedrock testnet.
 
-    hive --sim optimism/p2p --client=go-ethereum,op-geth,op-proposer,op-batcher,op-node,op-contracts --docker.output
+    hive --sim optimism/p2p --client=go-ethereum,op-geth,op-proposer,op-batcher,op-node --docker.output

--- a/simulators/optimism/rpc/README.md
+++ b/simulators/optimism/rpc/README.md
@@ -4,4 +4,4 @@ This test suite is a copy of the ETH L1 RPC test suite adapted for Optimism L2.
 It tests several real-world scenarios such as sending value transactions,
 deploying a contract or interacting with one.
 
-    hive --sim optimism/rpc --client=go-ethereum,op-geth,op-proposer,op-batcher,op-node,op-contracts --docker.output
+    hive --sim optimism/rpc --client=go-ethereum,op-geth,op-proposer,op-batcher,op-node --docker.output


### PR DESCRIPTION
**Description**

This client doesn't seem to exist anymore. This also added a new readme.

