### PR TITLE
Tx Forwarding test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   # This job builds the hive executable and stores it in the workspace.
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       # Build it.
       - checkout
@@ -63,7 +63,7 @@ jobs:
   # This job runs the go unit tests.
   go-test:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       # Get the source.
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   # to be able to talk to the docker containers it creates.
   run-hive-sim:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:2022.07.1
       docker_layer_caching: true
     parameters:
       sim:

--- a/clients/op-geth/entrypoint.sh
+++ b/clients/op-geth/entrypoint.sh
@@ -24,6 +24,16 @@ fi
 GAS_LIMIT_HEX=$(jq -r .gasLimit < /genesis.json | sed s/0x//i | tr '[:lower:]' '[:upper:]')
 GAS_LIMIT=$(echo "obase=10; ibase=16; $GAS_LIMIT_HEX" | bc)
 
+
+EXTRA_FLAGS="--rollup.disabletxpoolgossip=true"
+
+# We check for env variables that may not be bound so we need to disable `set -u` for this section.
+set +u
+if [ "$HIVE_OP_GETH_SEQUENCER_HTTP" != "" ]; then
+    EXTRA_FLAGS="$EXTRA_FLAGS --rollup.sequencerhttp $HIVE_OP_GETH_SEQUENCER_HTTP"
+fi
+set -u
+
 # Warning: Archive mode is required, otherwise old trie nodes will be
 # pruned within minutes of starting the devnet.
 
@@ -52,5 +62,5 @@ geth \
 	--password="$GETH_DATA_DIR"/password \
 	--allow-insecure-unlock \
 	--gcmode=archive \
-	--rollup.disabletxpoolgossip=true \
+	$EXTRA_FLAGS \
 	"$@"


### PR DESCRIPTION
**Description**

This adds a "tx forwarding" test to the `p2p` sim. It verifies that a transaction
sent to a replica that has tx forwarding enabled shows up on the sequencer.

It still has some remaining oddities:
- It could pass accidentally (not likely though) if no txpool gossip is not set
- The transaction is received by the sequencer EE, but it is not accepted into the L2 chain.

**Metadata**
- Fixes ENG-2714