### PR TITLE
hive: fix config for L2 genesis creation

### DIFF
--- a/optimism/devnet.go
+++ b/optimism/devnet.go
@@ -451,17 +451,7 @@ func (d *Devnet) InitChain(maxSeqDrift uint64, seqWindowSize uint64, chanTimeout
 	d.L1Cfg = l1Genesis
 
 	l1Block := l1Genesis.ToBlock()
-	l2Addrs := &genesis.L2Addresses{
-		ProxyAdminOwner:             predeploys.ProxyAdminAddr,
-		L1StandardBridgeProxy:       predeploys.DevL1StandardBridgeAddr,
-		L1CrossDomainMessengerProxy: predeploys.DevL1CrossDomainMessengerAddr,
-		L1ERC721BridgeProxy:         predeploys.DevL1ERC721BridgeAddr,
-		SequencerFeeVaultRecipient:  predeploys.SequencerFeeVaultAddr,
-		L1FeeVaultRecipient:         predeploys.L1FeeVaultAddr,
-		BaseFeeVaultRecipient:       predeploys.BaseFeeVaultAddr,
-	}
-
-	l2Genesis, err := genesis.BuildL2DeveloperGenesis(config, l1Block, l2Addrs)
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(config, l1Block, nil)
 	if err != nil {
 		d.T.Fatalf("failed to create l2 genesis: %v", err)
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Passing `nil` will use the correct addresses that should be used for development

Correctly sets up the `L2Addresses` struct to be used. Note that this struct has a poor name, it actually holds onto config information. I'd like to delete the `L2Addresses` struct from being used in favor of https://github.com/ethereum-optimism/optimism/pull/3871

I can add an additional method `GetDevAddresses` or something like that which will populate the `DeployConfig` with the dev addresses