### PR TITLE
Improve P2P Test logging & exit conditions

### DIFF
--- a/simulators/optimism/p2p/main.go
+++ b/simulators/optimism/p2p/main.go
@@ -178,6 +178,7 @@ func runP2PTests(t *hivesim.T) {
 					return
 				}
 				if seqHead.UnsafeL2.Number == seqHead.SafeL2.Number {
+					t.Log("Sequencer is unsafe head is at safe head", seqHead.SafeL2)
 					continue
 				}
 				ready := true
@@ -189,6 +190,7 @@ func runP2PTests(t *hivesim.T) {
 						return
 					}
 					if seqHead.UnsafeL2.Number-repHead.UnsafeL2.Number >= 2 {
+						t.Logf("Replica %d is not ready. Seq Unsafe Head: %v, Replica Unsafe Head: %v", i, seqHead.UnsafeL2, repHead.UnsafeL2)
 						ready = false
 						break
 					}


### PR DESCRIPTION
**Description**

This modifies the P2P test to not call `t.FailNow` from goroutines other than the main
go routine as well as providing more logging about the status of the test.
