### PR TITLE
Fix underflow in head number comparison

### DIFF
--- a/simulators/optimism/p2p/main.go
+++ b/simulators/optimism/p2p/main.go
@@ -213,8 +213,10 @@ waitLoop:
 		return seqStat, nil
 	}
 
+	// NB: head is from seq, id is from verif
 	checkCanon := func(i int, head uint64, id eth.BlockID) error {
-		if head-id.Number > maxReplicaLag {
+		// Convert to ints to stop this from underflowing and inccorectly error if the replica is ahead
+		if int(head)-int(id.Number) > maxReplicaLag {
 			return fmt.Errorf("replica %d: too far behind sequencer. seq head: %d, replica head: %d", i, head, id.Number)
 		}
 		bl, err := seqEthCl.BlockByNumber(ctx, big.NewInt(int64(id.Number)))


### PR DESCRIPTION
**Description**

I discovered that an underflow was potentially recording a test as having failed.
I saw the log line: `unhandled error: replica 2: too far behind sequencer. seq head: 16, replica head: 17`. The explanation for this is that the block numbers are uint64 and
underflow incorrectly triggering the check.
