### PR TITLE
Only send slack notifications for failures on the `optimism` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,9 @@ jobs:
           command: "! grep 'pass.*=false' /tmp/build/hive.log"
       - slack/notify:
           channel: C03N11M0BBN
+          branch_pattern: optimism
           event: fail
           template: basic_fail_1
-      - slack/notify:
-          channel: C03N11M0BBN
-          event: pass
-          template: basic_success_1
 
   # This job runs the go unit tests.
   go-test:


### PR DESCRIPTION
**Description**

Adjusts the slack notifications to only send a notification when a build of the `optimism` branch fails rather than on success or failure of any branch. Should make the `notify-hive` channel much less noisy and easier for people to pay attention to.
