### PR TITLE
Disable the scheduled job for running hive tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,16 +116,3 @@ workflows:
           requires: [ "build" ]
           context: slack
           sim: optimism/daisy-chain
-  scheduled:
-    triggers:
-      - schedule:
-          # run every 4 hours
-          cron: "0 0,4,8,12,16 * * *"
-          filters:
-            branches:
-              only: [ "optimism" ]
-    jobs:
-      - build
-      - run-hive-sim:
-          requires: ["build"]
-          context: slack


### PR DESCRIPTION
**Description**

The op-e2e tests in the monorepo now cover all the key things we were using hive for.


**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3593/spike-determine-future-of-hive
